### PR TITLE
fix: deploy link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <br>
 
-[![Deploy](https://button.deta.dev/1/svg)](https://go.deta.dev/deploy)
+[![Deploy](https://button.deta.dev/1/svg)](https://go.deta.dev/deploy?repo=https://github.com/viperadnan-git/tiiny)
 
 ## Deploy
 - Edit `index.js` to listen to app.


### PR DESCRIPTION
The deploy URL in the README was pointing to `https://go.deta.dev/deploy`.
I added the repo as argument.